### PR TITLE
Support for options as a single argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,18 @@ npm install giphy-api --save
 var giphy = require('giphy-api')('API KEY HERE');
 // Require with the public beta key
 var giphy = require('giphy-api')();
-
-// Require with specific timeout
-var giphy = require('giphy-api')(null, { timeout: 10000 });
 ```
+
+## Initialization Options
+
+```javascript
+var giphy = require('giphy-api')({
+    ...
+});
+```
+
+- timeout - Maximum timeout of an API request. Defaults to 30 seconds.
+- apiKey - Giphy API key. Defaults to API beta key
 
 ## [Phrase search](https://github.com/giphy/GiphyAPI#search-endpoint)
 Search all Giphy GIFs for a word or phrase. Supported parameters:

--- a/index.js
+++ b/index.js
@@ -24,11 +24,17 @@ var ENV_IS_BROWSER = process.browser || false;
 /**
 * @param apiKey Giphy API key. Defaults to the public beta API key
 */
-var GiphyAPI = function(apiKey, options) {
-    options = options || {};
-    
-    this.apiKey = apiKey || PUBLIC_BETA_API_KEY;
-    this.timeout = options && options.timeout || 30000;
+var GiphyAPI = function(options) {
+    if (typeof options === 'string' || typeof options === 'undefined') {
+        this.apiKey = options || PUBLIC_BETA_API_KEY;
+        options = {};
+    } else if (typeof options === 'object') {
+        this.apiKey = options.apiKey || PUBLIC_BETA_API_KEY;
+    } else {
+        throw new Error ('Invalid options passed to giphy-api');
+    }
+
+    this.timeout = options.timeout || 30000;
 };
 
 GiphyAPI.prototype = {
@@ -236,7 +242,7 @@ GiphyAPI.prototype = {
             });
 
             req.on('socket', function (socket) {
-                socket.setTimeout(self.timeout);  
+                socket.setTimeout(self.timeout);
                 socket.on('timeout', function() {
                     req.abort();
                 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ require('chai').should();
 var expect = require('chai').expect;
 
 describe('Giphy API', function() {
-    var giphy = Giphy();
+    var giphy = new Giphy();
 
     describe('The callback based api', function() {
         describe('Giphy Phrase Search', function() {
@@ -115,14 +115,6 @@ describe('Giphy API', function() {
 
             it('should throw error if Id array empty', function(done) {
                 giphy.id([], function(err, res) {
-                    expect(err).to.exist;
-                    done();
-                });
-            });
-            
-            it('should throw error if socket timeout', function(done) {
-                var giphyTimeout = new Giphy(null, { timeout: 1 });
-                giphyTimeout.id('feqkVgjJpYtjy', function(err, res) {
                     expect(err).to.exist;
                     done();
                 });
@@ -544,6 +536,83 @@ describe('Giphy API', function() {
                 }).then(function(res) {
                     expect(res.data).to.not.be.empty;
                 });
+            });
+        });
+    });
+
+    describe('Initialization', function() {
+        it('should allow initializing with no arguments', function(done) {
+            var giphy = new Giphy();
+            giphy.search({
+                q: 'funny'
+            }, function(err, res) {
+                expect(err).to.equal(null);
+                expect(res.data).to.not.be.empty;
+                done();
+            });
+        });
+
+        it('should allow initializing with api key string', function(done) {
+            // Use the public beta API key
+            var giphy = new Giphy('dc6zaTOxFJmzC');
+            giphy.search({
+                q: 'funny'
+            }, function(err, res) {
+                expect(err).to.equal(null);
+                expect(res.data).to.not.be.empty;
+                done();
+            });
+        });
+
+        it('should allow initializing with arguments with api key', function(done) {
+            // Use the public beta API key
+            var giphy = new Giphy({
+                apiKey: 'dc6zaTOxFJmzC'
+            });
+
+            giphy.search({
+                q: 'funny'
+            }, function(err, res) {
+                expect(err).to.equal(null);
+                expect(res.data).to.not.be.empty;
+                done();
+            });
+        });
+
+        it('should allow initializing with no api key', function(done) {
+            var giphy = new Giphy({
+                timeout: 5000
+            });
+
+            giphy.search({
+                q: 'funny'
+            }, function(err, res) {
+                expect(err).to.equal(null);
+                expect(res.data).to.not.be.empty;
+                done();
+            });
+        });
+
+        it('should allow initializing with empty object', function(done) {
+            var giphy = new Giphy({});
+
+            giphy.search({
+                q: 'funny'
+            }, function(err, res) {
+                expect(err).to.equal(null);
+                expect(res.data).to.not.be.empty;
+                done();
+            });
+        });
+
+        it('should receive error if socket timeout', function(done) {
+            var giphy = new Giphy({
+                timeout: 1
+            });
+
+            giphy.id('feqkVgjJpYtjy', function(err, res) {
+                expect(err).to.exist;
+                done();
             });
         });
     });


### PR DESCRIPTION
Support for the following as a single argument:

```javascript
var giphy = new Giphy();
var giphy = new Giphy('API_KEY_HERE');
var giphy = new Giphy({
    timeout: 5000
});
var giphy = new Giphy({
    apiKey: 'API_KEY_HERE',
    timeout: 5000
});
```