### PR TITLE
Fix Port for Requests when Using with Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ GiphyAPI.prototype = {
         }
 
         var requestOptions = {
-            hostname: API_HOSTNAME,
+            host: API_HOSTNAME,
             path: API_BASE_PATH + options.api + endpoint + query,
             withCredentials: !ENV_IS_BROWSER
         };


### PR DESCRIPTION
**Bug**
I'm using this package with webpack, on a test page at `localhost:4000`. This ends up making requests to api.giphy.com:4000/... which always fail. It seems that the Webpack shim for `http`/`https` fills in the port using `window.location.port` if one is not provided.

**Fix**
Change request options to use `host` instead of `hostname`. This stops webpack setting the port from `window.location.port`.