### PR TITLE
- adding try catch around JSON.parse to handle HTML response

### DIFF
--- a/util/http.js
+++ b/util/http.js
@@ -28,7 +28,11 @@ exports.get = function (options, resolve, reject) {
     });
     response.on('end', function () {
       if (fmt !== 'html') {
-        body = JSON.parse(body);
+        try {
+          body = JSON.parse(body);
+        } catch (e) {
+          reject(e);
+        }
       }
       resolve(body);
     });


### PR DESCRIPTION
When giphy was down last month this line was crashing the node process.